### PR TITLE
Distribute only for: win64, linux64 and Macos intel 64

### DIFF
--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -24,15 +24,9 @@ jobs:
     strategy:
       matrix:
         os:
-          - Windows_32bit
           - Windows_64bit
-          - Linux_32bit
           - Linux_64bit
-          - Linux_ARMv6
-          - Linux_ARMv7
-          - Linux_ARM64
           - macOS_64bit
-          - macOS_ARM64
 
     steps:
       - name: Checkout repository
@@ -42,7 +36,7 @@ jobs:
 
       - name: Create changelog
         # Avoid creating the same changelog for each os
-        if: matrix.os == 'Windows_32bit'
+        if: matrix.os == 'Windows_64bit'
         uses: arduino/create-changelog@v1
         with:
           tag-regex: '^[0-9]+\.[0-9]+\.[0-9]+.*$'
@@ -72,7 +66,6 @@ jobs:
     needs: create-release-artifacts
     outputs:
       checksum-darwin_amd64: ${{ steps.re-package.outputs.checksum-darwin_amd64 }}
-      checksum-darwin_arm64: ${{ steps.re-package.outputs.checksum-darwin_arm64 }}
     permissions:
       contents: read
 
@@ -84,8 +77,6 @@ jobs:
         artifact:
           - name: darwin_amd64
             path: "macOS_64bit.tar.gz"
-          - name: darwin_arm64
-            path: "macOS_ARM64.tar.gz"
 
     steps:
       - name: Checkout repository

--- a/DistTasks.yml
+++ b/DistTasks.yml
@@ -22,30 +22,6 @@ vars:
   GO_VERSION: "1.20.5"
 
 tasks:
-  Windows_32bit:
-    desc: Builds Windows 32 bit binaries
-    dir: "{{.DIST_DIR}}"
-    cmds:
-      - |
-        mkdir {{.PLATFORM_DIR}}
-        cp ../LICENSE.txt {{.PLATFORM_DIR}}/
-        docker run -v `pwd`/..:/home/build -w /home/build \
-        -e CGO_ENABLED=0 \
-        {{.CONTAINER}}:{{.CONTAINER_TAG}} \
-        --build-cmd "{{.BUILD_COMMAND}}" \
-        -p "{{.BUILD_PLATFORM}}"
-
-        zip {{.PACKAGE_NAME}} {{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe {{.PLATFORM_DIR}}/LICENSE.txt
-
-    vars:
-      PLATFORM_DIR: "{{.PROJECT_NAME}}_windows_386"
-      BUILD_COMMAND: >
-        go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}}.exe {{.LDFLAGS}}
-      BUILD_PLATFORM: "windows/386"
-      CONTAINER_TAG: "{{.GO_VERSION}}-main"
-      PACKAGE_PLATFORM: "Windows_32bit"
-      PACKAGE_NAME: "{{.PROJECT_NAME}}_{{.VERSION}}_{{.PACKAGE_PLATFORM}}.zip"
-
   Windows_64bit:
     desc: Builds Windows 64 bit binaries
     dir: "{{.DIST_DIR}}"
@@ -70,30 +46,6 @@ tasks:
       PACKAGE_PLATFORM: "Windows_64bit"
       PACKAGE_NAME: "{{.PROJECT_NAME}}_{{.VERSION}}_{{.PACKAGE_PLATFORM}}.zip"
 
-  Linux_32bit:
-    desc: Builds Linux 32 bit binaries
-    dir: "{{.DIST_DIR}}"
-    cmds:
-      - |
-        mkdir {{.PLATFORM_DIR}}
-        cp ../LICENSE.txt {{.PLATFORM_DIR}}/
-        docker run -v `pwd`/..:/home/build -w /home/build \
-        -e CGO_ENABLED=0 \
-        {{.CONTAINER}}:{{.CONTAINER_TAG}} \
-        --build-cmd "{{.BUILD_COMMAND}}" \
-        -p "{{.BUILD_PLATFORM}}"
-
-        tar cz {{.PLATFORM_DIR}} -f {{.PACKAGE_NAME}}
-
-    vars:
-      PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_amd32"
-      BUILD_COMMAND: >
-        go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}
-      BUILD_PLATFORM: "linux/386"
-      CONTAINER_TAG: "{{.GO_VERSION}}-main"
-      PACKAGE_PLATFORM: "Linux_32bit"
-      PACKAGE_NAME: "{{.PROJECT_NAME}}_{{.VERSION}}_{{.PACKAGE_PLATFORM}}.tar.gz"
-
   Linux_64bit:
     desc: Builds Linux 64 bit binaries
     dir: "{{.DIST_DIR}}"
@@ -116,78 +68,6 @@ tasks:
       BUILD_PLATFORM: "linux/amd64"
       CONTAINER_TAG: "{{.GO_VERSION}}-main"
       PACKAGE_PLATFORM: "Linux_64bit"
-      PACKAGE_NAME: "{{.PROJECT_NAME}}_{{.VERSION}}_{{.PACKAGE_PLATFORM}}.tar.gz"
-
-  Linux_ARMv7:
-    desc: Builds Linux ARMv7 binaries
-    dir: "{{.DIST_DIR}}"
-    cmds:
-      - |
-        mkdir {{.PLATFORM_DIR}}
-        cp ../LICENSE.txt {{.PLATFORM_DIR}}/
-        docker run -v `pwd`/..:/home/build -w /home/build \
-        -e CGO_ENABLED=0 \
-        {{.CONTAINER}}:{{.CONTAINER_TAG}} \
-        --build-cmd "{{.BUILD_COMMAND}}" \
-        -p "{{.BUILD_PLATFORM}}"
-
-        tar cz {{.PLATFORM_DIR}} -f {{.PACKAGE_NAME}}
-
-    vars:
-      PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_arm_7"
-      BUILD_COMMAND: >
-        go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}
-      BUILD_PLATFORM: "linux/armv7"
-      CONTAINER_TAG: "{{.GO_VERSION}}-armhf"
-      PACKAGE_PLATFORM: "Linux_ARMv7"
-      PACKAGE_NAME: "{{.PROJECT_NAME}}_{{.VERSION}}_{{.PACKAGE_PLATFORM}}.tar.gz"
-
-  Linux_ARMv6:
-    desc: Builds Linux ARMv6 binaries
-    dir: "{{.DIST_DIR}}"
-    cmds:
-      - |
-        mkdir {{.PLATFORM_DIR}}
-        cp ../LICENSE.txt {{.PLATFORM_DIR}}/
-        docker run -v `pwd`/..:/home/build -w /home/build \
-        -e CGO_ENABLED=0 \
-        {{.CONTAINER}}:{{.CONTAINER_TAG}} \
-        --build-cmd "{{.BUILD_COMMAND}}" \
-        -p "{{.BUILD_PLATFORM}}"
-
-        tar cz {{.PLATFORM_DIR}} -f {{.PACKAGE_NAME}}
-
-    vars:
-      PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_arm_6"
-      BUILD_COMMAND: >
-        go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}
-      BUILD_PLATFORM: "linux/armv6"
-      CONTAINER_TAG: "{{.GO_VERSION}}-armel-debian9"
-      PACKAGE_PLATFORM: "Linux_ARMv6"
-      PACKAGE_NAME: "{{.PROJECT_NAME}}_{{.VERSION}}_{{.PACKAGE_PLATFORM}}.tar.gz"
-
-  Linux_ARM64:
-    desc: Builds Linux ARM64 binaries
-    dir: "{{.DIST_DIR}}"
-    cmds:
-      - |
-        mkdir {{.PLATFORM_DIR}}
-        cp ../LICENSE.txt {{.PLATFORM_DIR}}/
-        docker run -v `pwd`/..:/home/build -w /home/build \
-        -e CGO_ENABLED=0 \
-        {{.CONTAINER}}:{{.CONTAINER_TAG}} \
-        --build-cmd "{{.BUILD_COMMAND}}" \
-        -p "{{.BUILD_PLATFORM}}"
-
-        tar cz {{.PLATFORM_DIR}} -f {{.PACKAGE_NAME}}
-
-    vars:
-      PLATFORM_DIR: "{{.PROJECT_NAME}}_linux_arm_64"
-      BUILD_COMMAND: >
-        go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}
-      BUILD_PLATFORM: "linux/arm64"
-      CONTAINER_TAG: "{{.GO_VERSION}}-arm"
-      PACKAGE_PLATFORM: "Linux_ARM64"
       PACKAGE_NAME: "{{.PROJECT_NAME}}_{{.VERSION}}_{{.PACKAGE_PLATFORM}}.tar.gz"
 
   macOS_64bit:
@@ -215,66 +95,21 @@ tasks:
       PACKAGE_PLATFORM: "macOS_64bit"
       PACKAGE_NAME: "{{.PROJECT_NAME}}_{{.VERSION}}_{{.PACKAGE_PLATFORM}}.tar.gz"
 
-  macOS_ARM64:
-    desc: Builds Mac OS X ARM64 binaries
-    dir: "{{.DIST_DIR}}"
-    cmds:
-      # "git config safe.directory" is required until this is fixed https://github.com/elastic/golang-crossbuild/issues/232
-      - |
-        mkdir {{.PLATFORM_DIR}}
-        cp ../LICENSE.txt {{.PLATFORM_DIR}}/
-        docker run -v `pwd`/..:/home/build -w /home/build \
-        -e CGO_ENABLED=0 \
-        {{.CONTAINER}}:{{.CONTAINER_TAG}} \
-        --build-cmd "git config --global --add safe.directory /home/build && {{.BUILD_COMMAND}}" \
-        -p "{{.BUILD_PLATFORM}}"
-
-        tar cz {{.PLATFORM_DIR}} -f {{.PACKAGE_NAME}}
-
-    vars:
-      PLATFORM_DIR: "{{.PROJECT_NAME}}_osx_darwin_arm64"
-      BUILD_COMMAND: >
-        go build -o {{.DIST_DIR}}/{{.PLATFORM_DIR}}/{{.PROJECT_NAME}} {{.LDFLAGS}}
-      BUILD_PLATFORM: "darwin/arm64"
-      CONTAINER_TAG: "{{.GO_VERSION}}-darwin-arm64-debian10"
-      PACKAGE_PLATFORM: "macOS_ARM64"
-      PACKAGE_NAME: "{{.PROJECT_NAME}}_{{.VERSION}}_{{.PACKAGE_PLATFORM}}.tar.gz"
-
   generate-index-data:
     desc: Generates json for platform index
     vars:
-      WINDOWS32_SHA:
-        sh: sha256sum {{ .DIST_DIR }}/{{ .PROJECT_NAME }}_{{ .VERSION }}_Windows_32bit.zip | cut -f1 -d " "
       WINDOWS64_SHA:
         sh: sha256sum {{ .DIST_DIR }}/{{ .PROJECT_NAME }}_{{ .VERSION }}_Windows_64bit.zip | cut -f1 -d " "
-      LINUX32_SHA:
-        sh: sha256sum {{ .DIST_DIR }}/{{ .PROJECT_NAME }}_{{ .VERSION }}_Linux_32bit.tar.gz | cut -f1 -d " "
       LINUX64_SHA:
         sh: sha256sum {{ .DIST_DIR }}/{{ .PROJECT_NAME }}_{{ .VERSION }}_Linux_64bit.tar.gz | cut -f1 -d " "
-      LINUXARM_SHA:
-        sh: sha256sum {{ .DIST_DIR }}/{{ .PROJECT_NAME }}_{{ .VERSION }}_Linux_ARMv6.tar.gz | cut -f1 -d " "
-      LINUXARM64_SHA:
-        sh: sha256sum {{ .DIST_DIR }}/{{ .PROJECT_NAME }}_{{ .VERSION }}_Linux_ARM64.tar.gz | cut -f1 -d " "
       OSX64_SHA:
         sh: sha256sum {{ .DIST_DIR }}/{{ .PROJECT_NAME }}_{{ .VERSION }}_macOS_64bit.tar.gz | cut -f1 -d " "
-      OSXARM64_SHA:
-        sh: sha256sum {{ .DIST_DIR }}/{{ .PROJECT_NAME }}_{{ .VERSION }}_macOS_ARM64.tar.gz | cut -f1 -d " "
-      WINDOWS32_SIZE:
-        sh: ls -la {{ .DIST_DIR }}/{{ .PROJECT_NAME }}_{{ .VERSION }}_Windows_32bit.zip | cut -f5 -d " "
       WINDOWS64_SIZE:
         sh: ls -la {{ .DIST_DIR }}/{{ .PROJECT_NAME }}_{{ .VERSION }}_Windows_64bit.zip | cut -f5 -d " "
-      LINUX32_SIZE:
-        sh: ls -la {{ .DIST_DIR }}/{{ .PROJECT_NAME }}_{{ .VERSION }}_Linux_32bit.tar.gz | cut -f5 -d " "
       LINUX64_SIZE:
         sh: ls -la {{ .DIST_DIR }}/{{ .PROJECT_NAME }}_{{ .VERSION }}_Linux_64bit.tar.gz | cut -f5 -d " "
-      LINUXARM_SIZE:
-        sh: ls -la {{ .DIST_DIR }}/{{ .PROJECT_NAME }}_{{ .VERSION }}_Linux_ARMv6.tar.gz | cut -f5 -d " "
-      LINUXARM64_SIZE:
-        sh: ls -la {{ .DIST_DIR }}/{{ .PROJECT_NAME }}_{{ .VERSION }}_Linux_ARM64.tar.gz | cut -f5 -d " "
       OSX64_SIZE:
         sh: ls -la {{ .DIST_DIR }}/{{ .PROJECT_NAME }}_{{ .VERSION }}_macOS_64bit.tar.gz | cut -f5 -d " "
-      OSXARM64_SIZE:
-        sh: ls -la {{ .DIST_DIR }}/{{ .PROJECT_NAME }}_{{ .VERSION }}_macOS_ARM64.tar.gz | cut -f5 -d " "
     cmds:
       - |
         cat extras/package_index.json.template |
@@ -282,18 +117,8 @@ tasks:
         sed "s/%%FILENAME%%/{{ .PROJECT_NAME }}/" |
         sed "s/%%LINUX64_SHA%%/{{ .LINUX64_SHA }}/" |
         sed "s/%%LINUX64_SIZE%%/{{ .LINUX64_SIZE }}/" |
-        sed "s/%%LINUX32_SHA%%/{{ .LINUX32_SHA }}/" |
-        sed "s/%%LINUX32_SIZE%%/{{ .LINUX32_SIZE }}/" |
-        sed "s/%%LINUXARM_SHA%%/{{ .LINUXARM_SHA }}/" |
-        sed "s/%%LINUXARM_SIZE%%/{{ .LINUXARM_SIZE }}/" |
-        sed "s/%%LINUXARM64_SHA%%/{{ .LINUXARM64_SHA }}/" |
-        sed "s/%%LINUXARM64_SIZE%%/{{ .LINUXARM64_SIZE }}/" |
         sed "s/%%OSX64_SHA%%/{{ .OSX64_SHA }}/" |
         sed "s/%%OSX64_SIZE%%/{{ .OSX64_SIZE }}/" |
-        sed "s/%%OSXARM64_SHA%%/{{ .OSXARM64_SHA }}/" |
-        sed "s/%%OSXARM64_SIZE%%/{{ .OSXARM64_SIZE }}/" |
-        sed "s/%%WINDOWS32_SHA%%/{{ .WINDOWS32_SHA }}/" |
-        sed "s/%%WINDOWS32_SIZE%%/{{ .WINDOWS32_SIZE }}/" |
         sed "s/%%WINDOWS64_SHA%%/{{ .WINDOWS64_SHA }}/" |
         sed "s/%%WINDOWS64_SIZE%%/{{ .WINDOWS64_SIZE }}/" \
         > {{ .DIST_DIR }}/package_index.json

--- a/extras/package_index.json.template
+++ b/extras/package_index.json.template
@@ -3,25 +3,11 @@
           "version": "%%VERSION%%",
           "systems": [
             {
-              "host": "i686-linux-gnu",
-              "url": "http://downloads.arduino.cc/arduino-fwuploader/plugins/portenta-c33-fwuploader-plugin/%%FILENAME%%_%%VERSION%%_Linux_32bit.tar.gz",
-              "archiveFileName": "%%FILENAME%%_%%VERSION%%_Linux_32bit.tar.gz",
-              "checksum": "SHA-256:%%LINUX32_SHA%%",
-              "size": "%%LINUX32_SIZE%%"
-            },
-            {
               "host": "x86_64-linux-gnu",
               "url": "http://downloads.arduino.cc/arduino-fwuploader/plugins/portenta-c33-fwuploader-plugin/%%FILENAME%%_%%VERSION%%_Linux_64bit.tar.gz",
               "archiveFileName": "%%FILENAME%%_%%VERSION%%_Linux_64bit.tar.gz",
               "checksum": "SHA-256:%%LINUX64_SHA%%",
               "size": "%%LINUX64_SIZE%%"
-            },
-            {
-              "host": "i686-mingw32",
-              "url": "http://downloads.arduino.cc/arduino-fwuploader/plugins/portenta-c33-fwuploader-plugin/%%FILENAME%%_%%VERSION%%_Windows_32bit.zip",
-              "archiveFileName": "%%FILENAME%%_%%VERSION%%_Windows_32bit.zip",
-              "checksum": "SHA-256:%%WINDOWS32_SHA%%",
-              "size": "%%WINDOWS32_SIZE%%"
             },
             {
               "host": "x86_64-mingw32",
@@ -36,27 +22,6 @@
               "archiveFileName": "%%FILENAME%%_%%VERSION%%_macOS_64bit.tar.gz",
               "checksum": "SHA-256:%%OSX64_SHA%%",
               "size": "%%OSX64_SIZE%%"
-            },
-            {
-              "host": "arm64-apple-darwin",
-              "url": "http://downloads.arduino.cc/arduino-fwuploader/plugins/portenta-c33-fwuploader-plugin/%%FILENAME%%_%%VERSION%%_macOS_ARM64.tar.gz",
-              "archiveFileName": "%%FILENAME%%_%%VERSION%%_macOS_ARM64.tar.gz",
-              "checksum": "SHA-256:%%OSXARM64_SHA%%",
-              "size": "%%OSXARM64_SIZE%%"
-            },
-            {
-              "host": "arm-linux-gnueabihf",
-              "url": "http://downloads.arduino.cc/arduino-fwuploader/plugins/portenta-c33-fwuploader-plugin/%%FILENAME%%_%%VERSION%%_Linux_ARMv6.tar.gz",
-              "archiveFileName": "%%FILENAME%%_%%VERSION%%_Linux_ARMv6.tar.gz",
-              "checksum": "SHA-256:%%LINUXARM_SHA%%",
-              "size": "%%LINUXARM_SIZE%%"
-            },
-            {
-              "host": "aarch64-linux-gnu",
-              "url": "http://downloads.arduino.cc/arduino-fwuploader/plugins/portenta-c33-fwuploader-plugin/%%FILENAME%%_%%VERSION%%_Linux_ARM64.tar.gz",
-              "archiveFileName": "%%FILENAME%%_%%VERSION%%_Linux_ARM64.tar.gz",
-              "checksum": "SHA-256:%%LINUXARM64_SHA%%",
-              "size": "%%LINUXARM64_SIZE%%"
             }
           ]
         },


### PR DESCRIPTION
We depend on 3-party tools that are not always distributed for every platform, therefore we have to match the same platforms.
